### PR TITLE
Add an item edit screen

### DIFF
--- a/components/TextBox.js
+++ b/components/TextBox.js
@@ -1,0 +1,60 @@
+import React from "react";
+import { StyleSheet, Text, TextInput, TouchableWithoutFeedback, View } from 'react-native';
+
+/* A component to standardize editing/entering information */
+export function TextBox({ label, suffix, placeholder, value, onChangeText, onEndEditing, keyboardType, style }) {
+  const textInputRef = React.useRef(null);
+
+  const styles = StyleSheet.create({
+    boundingBox: {
+      borderColor: "#d975d2",
+      borderWidth: 3,
+      borderRadius: 10,
+      height: 50,
+      backgroundColor: "#fff",
+      justifyContent: "center",
+    },
+    label: {
+      display: label ? "flex" : "none",
+      fontSize: 14,
+      color: "#330630",
+      marginHorizontal: 3,
+    },
+    inputWrapper: {
+      flexDirection: "row",
+      marginHorizontal: 5,
+      alignContent: "center"
+    },
+    input: {
+      width: suffix ? "75%" : "100%",
+      fontSize: 18,
+    },
+    suffix: {
+      fontSize: 18,
+      width: suffix ? "25%" : "0%",
+      textAlign: "right",
+      paddingRight: 10
+    },
+  });
+
+  return (
+    <View style={style}>
+      <TouchableWithoutFeedback
+        onPress={() => textInputRef.current.focus()}>
+        <View style={styles.boundingBox}>
+          <Text style={styles.label}>{label}</Text>
+          <View style={styles.inputWrapper}>
+            <TextInput style={styles.input}
+              ref={textInputRef}
+              value={value.toString()}
+              placeholder={placeholder}
+              keyboardType={keyboardType}
+              onChangeText={onChangeText}
+              onEndEditing={onEndEditing} />
+            <Text style={styles.suffix} numberOfLines={1}>{suffix}</Text>
+          </View>
+        </View>
+      </TouchableWithoutFeedback>
+    </View>
+  );
+}

--- a/models/Item.js
+++ b/models/Item.js
@@ -2,7 +2,7 @@
   A class representing a certain item in stock (e.g. cups)
 */
 export class Item {
-  constructor(name, amount, minimumAmount, defaultIncrement) {
+  constructor({ name, amount, minimumAmount, defaultIncrement }) {
     // What the item is called
     this.name = name;
 
@@ -14,5 +14,50 @@ export class Item {
 
     // The default number of items added or removed at one time
     this.defaultIncrement = defaultIncrement;
+  }
+
+  /*
+    Attempts to set the specified property and save.
+    If the property is not valid (i.e. value is not a number when it should be),
+    false is returned.
+  */
+  trySave(propertyName, value) {
+    if (propertyName === "name") {
+      if (value === "") {
+        return false;
+      }
+      this.name = value;
+    }
+    else { // numeric properties
+      const valueAsNumber = parseInt(value);
+      if (isNaN(valueAsNumber)) {
+        return false;
+      }
+
+      switch (propertyName) {
+        case ("amount"):
+          this.amount = valueAsNumber;
+          break;
+        case ("minimumAmount"):
+          this.minimumAmount = valueAsNumber;
+          break;
+        case ("defaultIncrement"):
+          this.defaultIncrement = valueAsNumber;
+          break;
+        default:
+          return false;
+      };
+    }
+
+    this.save();
+    return true;
+  }
+
+  /*
+    Save the item to the database.
+  */
+  save() {
+    console.log(`Saving! name=${this.name} amount=${this.amount} minimumAmount=${this.minimumAmount} defaultIncrement=${this.defaultIncrement}`);
+    // TODO: save in database
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,10 +9,14 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@react-navigation/native": "^6.0.13",
+    "@react-navigation/native-stack": "^6.9.0",
     "expo": "~46.0.9",
     "expo-status-bar": "~1.4.0",
     "react": "18.0.0",
-    "react-native": "0.69.5"
+    "react-native": "0.69.5",
+    "react-native-safe-area-context": "4.3.1",
+    "react-native-screens": "~3.15.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/screens/ItemEditScreen.js
+++ b/screens/ItemEditScreen.js
@@ -1,0 +1,149 @@
+import React from "react";
+import { Keyboard, KeyboardAvoidingView, StyleSheet, Text, TouchableOpacity, TouchableWithoutFeedback, View } from 'react-native';
+import { TextBox } from "../components/TextBox";
+
+/* A screen used to edit an item in inventory */
+export function ItemEditScreen({ navigation, route }) {
+  const item = route.params;
+  const [name, setName] = React.useState(item.name);
+  const [amount, setAmount] = React.useState(item.amount);
+  const [increment, setIncrement] = React.useState(item.defaultIncrement);
+  const [defaultIncrement, setDefaultIncrement] = React.useState(item.defaultIncrement);
+  const [minimumAmount, setMinimumAmount] = React.useState(item.minimumAmount);
+
+  React.useEffect(() => {
+    navigation.setOptions({ title: "Edit Trailer 1's " + name }); //TODO: don't hardcode site name
+  }, [navigation]);
+
+  return (
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <KeyboardAvoidingView>
+
+        {/* Name */}
+        <TextBox style={{ ...styles.row, ...styles.textBox }}
+          value={name}
+          placeholder="Enter Name"
+          label="Name"
+          onChangeText={(name) => {
+            setName(name);
+            navigation.setOptions({ title: "Edit Trailer 1's " + name }); //TODO: don't hardcode site name
+          }}
+          onEndEditing={() => {
+            item.trySave.bind(item)("name", name);
+            setName(item.name.toString());
+            navigation.setOptions({ title: "Edit Trailer 1's " + item.name });
+          }}
+        />
+
+        <View style={{ ...styles.row, ...styles.amountRow }}>
+          {/* Amount */}
+          <TextBox style={{ ...styles.textBox, ...styles.amountTextBox }}
+            value={amount}
+            placeholder="Enter Amount"
+            label="Amount"
+            suffix={name}
+            keyboardType="numeric"
+            onChangeText={setAmount}
+            onEndEditing={() => {
+              item.trySave.bind(item)("amount", amount);
+              setAmount(item.amount.toString());
+            }}
+          />
+
+          {/* Increment Amount */}
+          <TouchableOpacity
+            style={styles.incrementButton}
+            onPress={() => {
+              const incrementAsNumber = parseInt(increment);
+              if (!isNaN(incrementAsNumber) && item.trySave("amount", item.amount + incrementAsNumber)) {
+                setAmount(item.amount.toString());
+              }
+            }}>
+            <Text style={styles.incrementButtonText}>+</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.incrementButton}
+            onPress={() => {
+              const incrementAsNumber = parseInt(increment);
+              if (!isNaN(incrementAsNumber) && item.trySave("amount", item.amount - incrementAsNumber)) {
+                setAmount(item.amount.toString());
+              }
+            }}>
+            <Text style={styles.incrementButtonText}>&#8212;</Text>
+          </TouchableOpacity>
+
+          <TextBox style={{ ...styles.textBox, ...styles.incrementTextBox }}
+            value={increment}
+            placeholder="Enter amount to change"
+            keyboardType="numeric"
+            onChangeText={setIncrement}
+          />
+        </View>
+
+        {/* Default Increment */}
+        < TextBox style={{ ...styles.row, ...styles.textBox }}
+          value={defaultIncrement}
+          placeholder="Enter Increment"
+          label="Default Increment"
+          suffix={name}
+          keyboardType="numeric"
+          onChangeText={setDefaultIncrement}
+          onEndEditing={() => {
+            item.trySave.bind(item)("defaultIncrement", defaultIncrement);
+            setDefaultIncrement(item.defaultIncrement.toString());
+          }}
+        />
+
+        {/* Minimum Amount */}
+        <TextBox style={{ ...styles.row, ...styles.textBox }}
+          value={minimumAmount}
+          placeholder="Enter Notification Level"
+          label="Notification Level"
+          suffix={name}
+          keyboardType="numeric"
+          onChangeText={setMinimumAmount}
+          onEndEditing={() => {
+            item.trySave.bind(item)("minimumAmount", minimumAmount);
+            setMinimumAmount(item.minimumAmount.toString());
+          }}
+        />
+
+      </KeyboardAvoidingView>
+    </TouchableWithoutFeedback >
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    marginTop: 15
+  },
+  amountRow: {
+    flexDirection: "row",
+    alignItems: "center"
+  },
+  textBox: {
+    width: "90%",
+    marginLeft: 5
+  },
+  amountTextBox: {
+    width: "50%",
+    marginRight: "2%",
+  },
+  incrementButton: {
+    width: "10%",
+    aspectRatio: 1,
+    borderRadius: 10000,
+    backgroundColor: "#d975d2",
+    marginLeft: "1%",
+  },
+  incrementButtonText: {
+    textAlign: "center",
+    textAlignVertical: "center",
+    color: "#fff",
+    fontSize: 40,
+  },
+  incrementTextBox: {
+    marginLeft: "1%",
+    width: "15%"
+  }
+});


### PR DESCRIPTION
Currently there is no actual way to get to this screen, because hopefully we can navigate to it from the items list soon, so I attached a screenshot of what it looks like below.

![Screenshot_20221006-001101](https://user-images.githubusercontent.com/44212308/194213061-b4587ae8-2d8b-4243-adc6-336bf6711e5b.png)

I'm sure what exactly this page looks like will change, but I think this works for a demo.